### PR TITLE
Add collectionAction to store

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ myRecord.ripen({someData: 'abc'}).then(response => {
   // do something when the API returns a response
 });
 
+// Call collection actions through the store
+this.store.collectionAction('fruit', 'getAllCitrus', {someData: 'abc'})
+
 ```
 
 ## Customization

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,7 +1,8 @@
 import memberAction from './utils/member-action';
 import collectionAction from './utils/collection-action';
+import CollectionActionable from './mixins/collection-action-mixin';
 
 export const classOp = collectionAction;
 export const instanceOp = memberAction;
 
-export { collectionAction, memberAction };
+export { CollectionActionable, collectionAction, memberAction };

--- a/addon/mixins/collection-action-mixin.js
+++ b/addon/mixins/collection-action-mixin.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+
+  collectionAction(modelName, method, params) {
+    let instance = this.createRecord(modelName);
+    return instance[method](params);
+  }
+
+});

--- a/app/instance-initializers/ember-api-actions.js
+++ b/app/instance-initializers/ember-api-actions.js
@@ -1,0 +1,24 @@
+import { CollectionActionable } from 'ember-api-actions';
+
+export function initialize(application) { }
+
+export default {
+  name: 'ember-api-actions',
+  initialize: function(application) {
+
+    let store = null;
+    let emberVersion = parseFloat(Ember.VERSION);
+
+    if (emberVersion >= 2.1) {
+      store = application.lookup('service:store');
+    }
+    else if (emberVersion >= 1.13) {
+      store = application.container.lookup('service:store');
+    }
+    else {
+      store = application.container.lookup('store:application');
+    }
+
+    store.reopen(CollectionActionable);
+  }
+};

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -12,8 +12,8 @@ export default Ember.Controller.extend({
         fruit.getProperties(['id', 'name'])
       );
     },
-    ripenAllFruit(fruit) {
-      fruit.ripenAll({ test: 'ok' });
+    ripenAllFruit() {
+      this.store.collectionAction('fruit', 'ripenAll', { test: 'ok' });
     }
   }
   // END-SNIPPET


### PR DESCRIPTION
Since collection actions aren't related to an instance, it makes sense
to put them on the store (like `findAll`, etc.) instead of an instance.
This is a backwards-compatible change that just wraps the exisiting
instance method.

* Removes 1.11 compatibility (instance initializers not supported)
* Adds 1.13 back to travis

Discussion: https://github.com/mike-north/ember-api-actions/issues/8