### PR TITLE
Fix buildURL to match ember-data signature.

### DIFF
--- a/addon/utils/build-url.js
+++ b/addon/utils/build-url.js
@@ -2,12 +2,13 @@ import Ember from 'ember';
 
 const { assert } = Ember;
 
-export default function buildOperationUrl(record, opPath, requestType, intance=true) {
+export default function buildOperationUrl(record, opPath, requestType, instance=true) {
   assert('You must provide a path for instanceOp', opPath);
   const modelName = record.constructor.modelName || record.constructor.typeKey;
   let adapter = record.store.adapterFor(modelName);
   let path = opPath;
-  let baseUrl = adapter.buildURL(modelName, intance ? record.get('id') : null, requestType);
+  let snapshot = record._createSnapshot();
+  let baseUrl = adapter.buildURL(modelName, instance ? record.get('id') : null, snapshot, requestType);
 
   if (baseUrl.charAt(baseUrl.length - 1) === '/') {
     return `${baseUrl}${path}`;


### PR DESCRIPTION
This was missing the snapshot argument, which could screw up anyone
overriding buildUrl.