### PR TITLE
Update to ember-ajax@^2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-ajax": "2.0.0",
+    "ember-ajax": "^2.0.1",
     "ember-cli": "2.4.3",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",


### PR DESCRIPTION
ember-ajax@2.0.0 was yanked due to an issue (within a few hours of initial publishing). Also, `^2.0.1` is the default value being added to ember-cli apps (as of 2.6.0-beta.1).