### PR TITLE
add path parameter to override the 'id' parameter in path

### DIFF
--- a/addon/utils/build-url.js
+++ b/addon/utils/build-url.js
@@ -2,13 +2,13 @@ import Ember from 'ember';
 
 const { assert } = Ember;
 
-export default function buildOperationUrl(record, opPath, urlType, instance=true) {
+export default function buildOperationUrl(record, opPath, opPathParameter, urlType, instance=true) {
   assert('You must provide a path for instanceOp', opPath);
   let modelName = record.constructor.modelName || record.constructor.typeKey;
   let adapter = record.store.adapterFor(modelName);
   let path = opPath;
   let snapshot = record._createSnapshot();
-  let baseUrl = adapter.buildURL(modelName, instance ? record.get('id') : null, snapshot, urlType);
+  let baseUrl = adapter.buildURL(modelName, instance ? record.get(opPathParameter) : null, snapshot, urlType);
 
   if (baseUrl.charAt(baseUrl.length - 1) === '/') {
     return `${baseUrl}${path}`;

--- a/addon/utils/collection-action.js
+++ b/addon/utils/collection-action.js
@@ -7,7 +7,8 @@ export default function instanceOp(options) {
     let requestType = options.type || 'PUT';
     let urlType = options.urlType || requestType;
     let adapter = this.store.adapterFor(modelName);
-    let fullUrl = buildOperationUrl(this, options.path, urlType, false);
+    let pathParameter = options.pathParameter || 'id';
+    let fullUrl = buildOperationUrl(this, options.path, pathParameter, urlType, false);
     return adapter.ajax(fullUrl, requestType, Ember.$.extend({}, options.ajaxOptions, { data: payload }));
   };
 }

--- a/addon/utils/member-action.js
+++ b/addon/utils/member-action.js
@@ -7,7 +7,8 @@ export default function instanceOp(options) {
     let requestType = options.type || 'PUT';
     let urlType = options.urlType || requestType;
     let adapter = this.store.adapterFor(modelName);
-    let fullUrl = buildOperationUrl(this, options.path, urlType);
+    let pathParameter = options.pathParameter || 'id';
+    let fullUrl = buildOperationUrl(this, options.path, pathParameter, urlType);
     return adapter.ajax(fullUrl, requestType, Ember.$.extend({}, options.ajaxOptions, { data: payload }));
   };
 }


### PR DESCRIPTION
Hi,

I add a new parameter in memberAction : 'pathParameter'
This parameter allow you to override the default 'id' parameter in path.

For exemple i have this model : 
```
//otp.js
export default DS.Model.extend({
  creationDate        : DS.attr('instant'),
  phoneNumber         : DS.attr('string'),

  generate            : memberAction({path: ' ', pathParameter: 'phoneNumber', type: 'PUT'})
});
```

With the parameter `pathParameter` i can call the endpoint : 

> PUT /api/otps/+33123456789/

I don't know if you want me to add tests. Tell me if you want.
Anyway, thanks for this great addon ;)

Regards,
Arnaud