### PR TITLE
Get primary key from serializer instead of default 'id'

### DIFF
--- a/addon/utils/build-url.js
+++ b/addon/utils/build-url.js
@@ -6,9 +6,11 @@ export default function buildOperationUrl(record, opPath, urlType, instance=true
   assert('You must provide a path for instanceOp', opPath);
   let modelName = record.constructor.modelName || record.constructor.typeKey;
   let adapter = record.store.adapterFor(modelName);
+  let serializer = record.store.serializerFor(modelName);
+  let primaryKey = serializer.get('primaryKey');
   let path = opPath;
   let snapshot = record._createSnapshot();
-  let baseUrl = adapter.buildURL(modelName, instance ? record.get('id') : null, snapshot, urlType);
+  let baseUrl = adapter.buildURL(modelName, instance ? record.get(primaryKey) : null, snapshot, urlType);
 
   if (baseUrl.charAt(baseUrl.length - 1) === '/') {
     return `${baseUrl}${path}`;


### PR DESCRIPTION
Hi again Mike, i'm back ;)

My first PR (https://github.com/mike-north/ember-api-actions/pull/40) was to specific.
Here is a new PR much more generic.

In the `DS.JSONAPISerializer` [API](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#property_primaryKey) , you can change the primaryKey for all models or a specific model.
In your addon, when you build the URL, you choose the primaryKey 'id' instead of getting the primaryKey set in the serializer.

Of course if not primaryKey is set in the serializer, the default value is 'id' :)