### PR TITLE
PushToStore and normalizePayload features

### DIFF
--- a/addon/config.js
+++ b/addon/config.js
@@ -1,0 +1,6 @@
+export default {
+  type: 'PUT',
+  ajaxOptions: {},
+  pushToStore: false,
+  normalizeOperation: ''
+};

--- a/addon/utils/build-url.js
+++ b/addon/utils/build-url.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 const { assert } = Ember;
 
-export function buildOperationUrl(record, opPath, urlType, instance=true) {
+export default function buildOperationUrl(record, opPath, urlType, instance=true) {
   assert('You must provide a path for instanceOp', opPath);
   let modelName = record.constructor.modelName || record.constructor.typeKey;
   let adapter = record.store.adapterFor(modelName);
@@ -16,5 +16,3 @@ export function buildOperationUrl(record, opPath, urlType, instance=true) {
     return `${baseUrl}/${path}`;
   }
 }
-
-export default buildOperationUrl;

--- a/addon/utils/collection-action.js
+++ b/addon/utils/collection-action.js
@@ -1,15 +1,7 @@
-import Ember from 'ember';
-import { buildOperationUrl } from './build-url';
+import customAction from './custom-action';
 
-const { merge } = Ember;
-
-export default function instanceOp(options) {
+export default function(options) {
   return function(payload) {
-    let modelName = this.constructor.modelName || this.constructor.typeKey;
-    let requestType = (options.type || 'PUT').toUpperCase();
-    let urlType = options.urlType || requestType;
-    let adapter = this.store.adapterFor(modelName);
-    let fullUrl = buildOperationUrl(this, options.path, urlType, false);
-    return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload }));
+    return customAction(this, options, payload, false);
   };
 }

--- a/addon/utils/custom-action.js
+++ b/addon/utils/custom-action.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+import buildUrl from './build-url';
+import normalizePayload from './normalize-payload';
+import defaultConfig from '../config';
+
+const { assign, getOwner } = Ember;
+
+function ajaxData(config, payload) {
+  let data = normalizePayload((payload instanceof Object) ? payload : {}, config.normalizeOperation);
+  return assign(config.ajaxOptions, { data });
+}
+
+function appConfig(model) {
+  return getOwner(model).resolveRegistration('config:environment')['ember-api-actions'] || {};
+}
+
+export default function(model, options, payload, instance) {
+  let modelName = model.constructor.modelName || model.constructor.typeKey;
+  let adapter =  model.store.adapterFor(modelName);
+  let serializer =  model.store.serializerFor(modelName);
+  let config = assign(defaultConfig, appConfig(model), options);
+
+  let requestType = config.type.toUpperCase();
+  let urlType = config.urlType || requestType;
+  let url = buildUrl(model, config.path, urlType, instance);
+  let data = ajaxData(config, payload);
+
+  return adapter.ajax(url, requestType, data).then((response) => {
+    return config.pushToStore ? serializer.pushPayload(model.store, response) : response;
+  });
+}

--- a/addon/utils/custom-action.js
+++ b/addon/utils/custom-action.js
@@ -26,6 +26,6 @@ export default function(model, options, payload, instance) {
   let data = ajaxData(config, payload);
 
   return adapter.ajax(url, requestType, data).then((response) => {
-    return config.pushToStore ? serializer.pushPayload(model.store, response) : response;
+    return config.pushToStore && response.data ? serializer.pushPayload(model.store, response) : response;
   });
 }

--- a/addon/utils/member-action.js
+++ b/addon/utils/member-action.js
@@ -1,15 +1,7 @@
-import Ember from 'ember';
-import { buildOperationUrl } from './build-url';
+import customAction from './custom-action';
 
-const { merge } = Ember;
-
-export default function instanceOp(options) {
+export default function(options) {
   return function(payload) {
-    let modelName = this.constructor.modelName || this.constructor.typeKey;
-    let requestType = (options.type || 'PUT').toUpperCase();
-    let urlType = options.urlType || requestType;
-    let adapter = this.store.adapterFor(modelName);
-    let fullUrl = buildOperationUrl(this, options.path, urlType);
-    return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload }));
+    return customAction(this, options, payload, true);
   };
 }

--- a/addon/utils/normalize-payload.js
+++ b/addon/utils/normalize-payload.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+
+const { assert } = Ember;
+
+function transformObject(object, operation) {
+  if (object instanceof Object) {
+    let data = {};
+
+    Object.keys(object).forEach((key) => {
+      data[key[operation]()] = transformObject(object[key], operation);
+    });
+
+    return data;
+  } else {
+    return object;
+  }
+}
+
+export default function(payload, operation) {
+  if (operation) {
+    assert("This normalize method of custom action's payload does not exist. Check Ember.String documentation!", !!Ember.String[operation]); // jscs:ignore disallowDirectPropertyAccess
+    return transformObject(payload, operation);
+  } else {
+    return payload;
+  }
+}


### PR DESCRIPTION
Hi @mike-north ,
I've just created a PR with features that we are using in our production app.
It brings:
## 1. Custom default settings (defined in app environment file)
You can define your custom default settings in your `config/environment.js` file. Example:

```js
module.exports = function(environment) {
  var ENV = {
    'ember-api-actions': {
      type: 'PUT',
      ajaxOptions: {},
      pushToStore: false,
      normalizeOperation: ''
    },
  };

  return ENV;
}
```

## 2. Payload transformer
Thanks do `normalizeOperation` option you can define how your outgoing data should be serialized.

Example:
```js
{
  firstParam: 'My Name',
  colors: { rubyRed: 1, blueFish: 3 }
}
```
using a `dasherize` transformer our request data will be look like:

```js
{
  first-param: 'My Name',
  colors: { ruby-red: 1, blue-fish: 3 }
}
```
It's great for API with request data format restrictions.

**Available transformers:**
  - camelize
  - capitalize
  - classify
  - dasherize
  - decamelize
  - underscore

## 3. Built in Push To Store option
You can automatically push response object with `included` objects (in case of JSONAPI) to the store by setting `pushToStore` option to true.