### PR TITLE
Make path optional

### DIFF
--- a/addon/utils/build-url.js
+++ b/addon/utils/build-url.js
@@ -1,19 +1,18 @@
-import Ember from 'ember';
-
-const { assert } = Ember;
-
 export function buildOperationUrl(record, opPath, urlType, instance = true) {
-  assert('You must provide a path for instanceOp', opPath);
   let modelName = record.constructor.modelName || record.constructor.typeKey;
   let adapter = record.store.adapterFor(modelName);
   let path = opPath;
   let snapshot = record._createSnapshot();
   let baseUrl = adapter.buildURL(modelName, instance ? record.get('id') : null, snapshot, urlType);
 
-  if (baseUrl.charAt(baseUrl.length - 1) === '/') {
-    return `${baseUrl}${path}`;
+  if (path) {
+    if (baseUrl.charAt(baseUrl.length - 1) === '/') {
+      return `${baseUrl}${path}`;
+    } else {
+      return `${baseUrl}/${path}`;
+    }
   } else {
-    return `${baseUrl}/${path}`;
+    return baseUrl;
   }
 }
 

--- a/addon/utils/build-url.js
+++ b/addon/utils/build-url.js
@@ -6,13 +6,17 @@ export function buildOperationUrl(record, opPath, urlType, instance = true) {
   let baseUrl = adapter.buildURL(modelName, instance ? record.get('id') : null, snapshot, urlType);
 
   if (path) {
-    if (baseUrl.charAt(baseUrl.length - 1) === '/') {
-      return `${baseUrl}${path}`;
-    } else {
-      return `${baseUrl}/${path}`;
-    }
+    return _joinUrl(baseUrl, path);
   } else {
     return baseUrl;
+  }
+}
+
+function _joinUrl(baseUrl, path) {
+  if (baseUrl.charAt(baseUrl.length - 1) === '/') {
+    return `${baseUrl}${path}`;
+  } else {
+    return `${baseUrl}/${path}`;
   }
 }
 


### PR DESCRIPTION
This resolves #100.

Short Description
-----------------

When using ember-api-actions with ember-data-url-templates, you can pass a `urlType` to `memberAction` and then define a template specifically for your new `urlType`. For example:

    // model
    ripen: memberAction({ urlType: 'ripen' }),

    // adapter
    ripenUrlTemplate: '/fruits/{id}/ripen.json',

However, this breaks down when adding a path.