### PR TITLE
Added an "extract" option property to "pass" related response key to promise resolve.  

### DIFF
--- a/addon/utils/collection-action.js
+++ b/addon/utils/collection-action.js
@@ -4,12 +4,23 @@ import { buildOperationUrl } from './build-url';
 const { merge } = Ember;
 
 export default function instanceOp(options) {
-  return function(payload) {
-    let modelName = this.constructor.modelName || this.constructor.typeKey;
-    let requestType = (options.type || 'PUT').toUpperCase();
-    let urlType = options.urlType || requestType;
-    let adapter = this.store.adapterFor(modelName);
-    let fullUrl = buildOperationUrl(this, options.path, urlType, false);
-    return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload }));
-  };
+    return function(payload) {
+        let modelName = this.constructor.modelName || this.constructor.typeKey;
+        let requestType = (options.type || 'PUT').toUpperCase();
+        let urlType = options.urlType || requestType;
+        let adapter = this.store.adapterFor(modelName);
+        let fullUrl = buildOperationUrl(this, options.path, urlType, false);
+        let extract = options.extract;
+        return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload })).then(function(response) {
+            if (extract) {
+                if (response && response[extract] !== null) {
+                    return Ember.RSVP.response(response[extract]);
+                } else {
+                    return Ember.RSVP.reject(new Error('Response malformed'));
+                }
+            } else {
+                return Ember.RSVP.response(response);
+            }
+        });
+    };
 }

--- a/addon/utils/collection-action.js
+++ b/addon/utils/collection-action.js
@@ -11,16 +11,18 @@ export default function instanceOp(options) {
         let adapter = this.store.adapterFor(modelName);
         let fullUrl = buildOperationUrl(this, options.path, urlType, false);
         let extract = options.extract;
-        return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload })).then(function(response) {
-            if (extract) {
-                if (response && response[extract] !== null) {
-                    return Ember.RSVP.resolve(response[extract]);
+        return new Ember.RSVP.Promise(function(resolve, reject) {
+            return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload })).then(function(response) {
+                if (extract) {
+                    if (response && response[extract] !== null) {
+                        return resolve(response[extract]);
+                    } else {
+                        return reject(new Error('Response malformed'));
+                    }
                 } else {
-                    return Ember.RSVP.reject(new Error('Response malformed'));
+                    return resolve(response);
                 }
-            } else {
-                return Ember.RSVP.resolve(response);
-            }
+            }).catch(reject);
         });
     };
 }

--- a/addon/utils/collection-action.js
+++ b/addon/utils/collection-action.js
@@ -14,12 +14,12 @@ export default function instanceOp(options) {
         return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload })).then(function(response) {
             if (extract) {
                 if (response && response[extract] !== null) {
-                    return Ember.RSVP.response(response[extract]);
+                    return Ember.RSVP.resolve(response[extract]);
                 } else {
                     return Ember.RSVP.reject(new Error('Response malformed'));
                 }
             } else {
-                return Ember.RSVP.response(response);
+                return Ember.RSVP.resolve(response);
             }
         });
     };

--- a/addon/utils/member-action.js
+++ b/addon/utils/member-action.js
@@ -11,16 +11,18 @@ export default function instanceOp(options) {
         let adapter = this.store.adapterFor(modelName);
         let fullUrl = buildOperationUrl(this, options.path, urlType);
         let extract = options.extract;
-        return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload })).then(function(response) {
-            if (extract) {
-                if (response && response[extract] !== null) {
-                    return Ember.RSVP.resolve(response[extract]);
+        return new Ember.RSVP.Promise(function(resolve, reject) {
+            return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload })).then(function(response) {
+                if (extract) {
+                    if (response && response[extract] !== null) {
+                        return resolve(response[extract]);
+                    } else {
+                        return reject(new Error('Response malformed'));
+                    }
                 } else {
-                    return Ember.RSVP.reject(new Error('Response malformed'));
+                    return resolve(response);
                 }
-            } else {
-                return Ember.RSVP.resolve(response);
-            }
+            }).catch(reject);
         });
     };
 }

--- a/addon/utils/member-action.js
+++ b/addon/utils/member-action.js
@@ -4,12 +4,23 @@ import { buildOperationUrl } from './build-url';
 const { merge } = Ember;
 
 export default function instanceOp(options) {
-  return function(payload) {
-    let modelName = this.constructor.modelName || this.constructor.typeKey;
-    let requestType = (options.type || 'PUT').toUpperCase();
-    let urlType = options.urlType || requestType;
-    let adapter = this.store.adapterFor(modelName);
-    let fullUrl = buildOperationUrl(this, options.path, urlType);
-    return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload }));
-  };
+    return function(payload) {
+        let modelName = this.constructor.modelName || this.constructor.typeKey;
+        let requestType = (options.type || 'PUT').toUpperCase();
+        let urlType = options.urlType || requestType;
+        let adapter = this.store.adapterFor(modelName);
+        let fullUrl = buildOperationUrl(this, options.path, urlType);
+        let extract = options.extract;
+        return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload })).then(function(response) {
+            if (extract) {
+                if (response && response[extract] !== null) {
+                    return Ember.RSVP.response(response[extract]);
+                } else {
+                    return Ember.RSVP.reject(new Error('Response malformed'));
+                }
+            } else {
+                return Ember.RSVP.response(response);
+            }
+        });
+    };
 }

--- a/addon/utils/member-action.js
+++ b/addon/utils/member-action.js
@@ -14,12 +14,12 @@ export default function instanceOp(options) {
         return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload })).then(function(response) {
             if (extract) {
                 if (response && response[extract] !== null) {
-                    return Ember.RSVP.response(response[extract]);
+                    return Ember.RSVP.resolve(response[extract]);
                 } else {
                     return Ember.RSVP.reject(new Error('Response malformed'));
                 }
             } else {
-                return Ember.RSVP.response(response);
+                return Ember.RSVP.resolve(response);
             }
         });
     };

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}


### PR DESCRIPTION
Useful if response is like {
  response: "somethingveryuseful"
}

so passing {extract: "response"} you'll receive "somethingveryuseful" instead of main object in your "then" handler.