### PR TITLE
Payload to buildurl

### DIFF
--- a/addon/utils/build-url.js
+++ b/addon/utils/build-url.js
@@ -1,12 +1,12 @@
 import { assert } from '@ember/debug';
 
-export function buildOperationUrl(record, opPath, urlType, instance = true) {
+export function buildOperationUrl(record, opPath, urlType, instance, payload) {
   assert('You must provide a path for instanceOp', opPath);
   let modelName = record.constructor.modelName || record.constructor.typeKey;
   let adapter = record.store.adapterFor(modelName);
   let path = opPath;
   let snapshot = record._createSnapshot();
-  let baseUrl = adapter.buildURL(modelName, instance ? record.get('id') : null, snapshot, urlType);
+  let baseUrl = adapter.buildURL(modelName, instance ? record.get('id') : null, snapshot, urlType, payload);
 
   if (baseUrl.charAt(baseUrl.length - 1) === '/') {
     return `${baseUrl}${path}`;

--- a/addon/utils/collection-action.js
+++ b/addon/utils/collection-action.js
@@ -7,7 +7,7 @@ export default function instanceOp(options) {
     let requestType = (options.type || 'PUT').toUpperCase();
     let urlType = options.urlType || requestType;
     let adapter = this.store.adapterFor(modelName);
-    let fullUrl = buildOperationUrl(this, options.path, urlType, false);
+    let fullUrl = buildOperationUrl(this, options.path, urlType, false, payload);
     return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload }));
   };
 }

--- a/addon/utils/member-action.js
+++ b/addon/utils/member-action.js
@@ -7,7 +7,7 @@ export default function instanceOp(options) {
     let requestType = (options.type || 'PUT').toUpperCase();
     let urlType = options.urlType || requestType;
     let adapter = this.store.adapterFor(modelName);
-    let fullUrl = buildOperationUrl(this, options.path, urlType);
+    let fullUrl = buildOperationUrl(this, options.path, urlType, true, payload);
     return adapter.ajax(fullUrl, requestType, merge(options.ajaxOptions || {}, { data: payload }));
   };
 }

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -33,13 +33,13 @@ test('visiting /', function(assert) {
   });
 
   server.get('/fruits/:id/info', request => {
-    assert.equal(request.url, '/fruits/1/info?fruitId=1');
+    assert.equal(request.url, '/fruits/1/info?fruitId=1&harvest=true');
     assert.ok(true, 'request was made to "ripenEverything"');
     return [200, {}, '{"status": "ok"}'];
   });
 
   server.get('/fruits/fresh', request => {
-    assert.equal(request.url, '/fruits/fresh?month=July');
+    assert.equal(request.url, '/fruits/fresh?month=July&harvest=true');
     assert.ok(true, 'request was made to "ripenEverything"');
     return [200, {}, '{"status": "ok"}'];
   });

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -2,4 +2,13 @@ import DS from 'ember-data';
 
 const { JSONAPIAdapter, RESTAdapter } = DS;
 
-export default (JSONAPIAdapter || RESTAdapter).extend({});
+export default (JSONAPIAdapter || RESTAdapter).extend({
+
+  buildURL(modelName, id, snapshot, requestType, queryParams) {
+    // For testing, to make sure that queryParams are passed to buildURL
+    if(queryParams && queryParams.harvest === 'yes') {
+      queryParams.harvest = true;
+    }
+    return this._super(...arguments);
+  }
+});

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -13,13 +13,13 @@ export default Controller.extend({
     },
     fruitInfo(fruit) {
       let { id } = fruit.getProperties(['id', 'name']);
-      fruit.info({ fruitId: id });
+      fruit.info({ fruitId: id, harvest: 'yes' });
     },
     ripenAllFruit(fruit) {
       fruit.ripenAll({ test: 'ok' });
     },
     getAllFreshFruit(fruit) {
-      fruit.getFresh({ month: 'July' });
+      fruit.getFresh({ month: 'July', harvest: 'yes' });
     }
   }
   // END-SNIPPET


### PR DESCRIPTION
Payload/queryparams can now be passed to buildURL in the adapter, so that they can affect the generated base URL or be modified as needed