### PR TITLE
Update `.npmignore` and `.gitignore` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # compiled output
 /dist/
 /tmp/
+*.tgz
 
 # dependencies
 /bower_components/

--- a/.npmignore
+++ b/.npmignore
@@ -6,24 +6,20 @@
 /bower_components/
 
 # misc
-/.bowerrc
-/.editorconfig
-/.ember-cli
-/.eslintignore
-/.eslintrc.js
-/.gitignore
-/.template-lintrc.js
-/.travis.yml
-/.watchmanconfig
-/bower.json
+/tests/
+/types/
+/.*
 /config/ember-try.js
 /ember-cli-build.js
+/renovate.json
 /testem.js
-/tests/
+/tsconfig.json
+/tslint.json
 /yarn.lock
+/yarn-error.log
 .gitkeep
+*.tgz
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
 /package.json.ember-try


### PR DESCRIPTION
Resolves https://github.com/mike-north/ember-api-actions/issues/410

```
npm notice === Tarball Details ===
npm notice name:          ember-api-actions
npm notice package size:  8.3 kB
npm notice unpacked size: 26.2 kB
```

/cc @mike-north 