### PR TITLE
Get CI Passing Again

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    snippetSearchPaths: ['tests/dummy/app']
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "release": {
     "extends": "@mike-north/js-lib-semantic-release-config"
   },
-  "toolchain": {
+  "volta": {
     "node": "8.11.4",
     "yarn": "1.9.2"
   }


### PR DESCRIPTION
The issue with CI was ultimately that `ember-code-snippet` couldn't find the code snippets and "blows up" if the snippet being referenced doesn't actually exist.

In this case, the snippets _did_ exist, but only the `app` directory is searched by default. All of these snippets live in `tests/dummy/app` so we need to give `ember-code-snippet` a handle and let it know about that!

In addition, Volta locally was warning me that the configuration key used here was wrong, so I tweaked that to resolve the warning. I'd love to migrate this to use GitHub Actions for testing, so we can lean on `volta-cli/action` for hooking Node and Yarn up in CI, but... one step at a time. If that's something we're interested in doing, I can do that real quick -- I have a number of add-ons using it with `ember-try`

cc: @dbollinger let's get this party started 😝 