### PR TITLE
breaking: Drop support for Node.js 8 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 8
+  - 10
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "repository": "https://github.com/mike-north/ember-api-actions.git",
   "homepage": "https://github.com/mike-north/ember-api-actions",
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "10.* || >= 12.*"
   },
   "author": "Mike North <michael.l.north@gmail.com> (http://mike.works)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "extends": "@mike-north/js-lib-semantic-release-config"
   },
   "volta": {
-    "node": "8.11.4",
+    "node": "10.19.0",
     "yarn": "1.9.4"
   }
 }


### PR DESCRIPTION
Node.js 8 is no longer maintained by the Node team since the beginning of this year