### PR TITLE
chore: Drop support for Ember v3.19 and below

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ember-try-scenario: [ember-lts-2.16, ember-lts-2.18, ember-release, ember-beta, ember-canary, ember-default-with-jquery]
+        ember-try-scenario:
+          - ember-lts-2.16
+          - ember-lts-2.18
+          - ember-release
+          - ember-beta
+          - ember-canary
+          - ember-default-with-jquery
     steps:
     - uses: actions/checkout@v1
     - uses: volta-cli/action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
         ember-try-scenario:
           - ember-lts-2.16
           - ember-lts-2.18
+          - ember-lts-3.20
+          - ember-lts-3.24
           - ember-release
           - ember-beta
           - ember-canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,6 @@ jobs:
     strategy:
       matrix:
         ember-try-scenario:
-          - ember-lts-2.16
-          - ember-lts-2.18
           - ember-lts-3.20
           - ember-lts-3.24
           - ember-release

--- a/README.md
+++ b/README.md
@@ -154,16 +154,6 @@ Customizing your adapter should customize requests sent out via this library, al
 - [buildURL](http://emberjs.com/api/data/classes/DS.RESTAdapter.html#method_buildURL) - for generating an action's URL
 - [ajax](https://github.com/emberjs/data/blob/v1.13.4/packages/ember-data/lib/adapters/rest-adapter.js#L836-L859) (private) - to actually make the API request and return a promise
 
-## Compatibility
-
-This addon is known to work with certain combinations of ember.js and ember-data
-
-| Ember.js               | Ember-data                                       |
-| ---------------------- | ------------------------------------------------ |
-| `1.10 <= ember < 1.13` | `1.0.0-beta.16.0 <= ember-data <= 1.0.0-beta.19` |
-| `1.13.x`               | `1.13.x`                                         |
-| `2.0.x`                | `2.0.x`                                          |
-
 ## Installation
 
 - `git clone` this repository

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,30 +7,6 @@ module.exports = async function() {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-2.16',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
-        },
-        npm: {
-          devDependencies: {
-            '@ember/jquery': '^0.5.1',
-            'ember-source': '~2.16.0'
-          }
-        }
-      },
-      {
-        name: 'ember-lts-2.18',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
-        },
-        npm: {
-          devDependencies: {
-            '@ember/jquery': '^0.5.1',
-            'ember-source': '~2.18.0'
-          }
-        }
-      },
-      {
         name: 'ember-lts-3.20',
         npm: {
           devDependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -31,6 +31,22 @@ module.exports = async function() {
         }
       },
       {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.5',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-3.24',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.24.3',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
The need for a change like this came on my radar due to #428, where the tests are valid for newer Ember versions but not for the `2.X` series.

At this point, for a modern add-on, it doesn't make a ton of sense to support these older versions of Ember. If a user needs to use one of these versions, they can stay on the most-recent-at-time-of-writing version the package. Older versions _may_ work in the future, but as we're not testing against then, this should be considered a breaking change (and the commit that bumps the minimum version tested against is marked as such, conventional-commit style).