### PR TITLE
chore(TravisCI): Remove testing jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,74 +8,17 @@ dist: trusty
 cache:
   yarn: true
 
-env:
-  global:
-    # See https://git.io/vdao3 for details.
-    - JOBS=1
-
 stages:
-  - 'Tests'
-  - 'Additional Tests'
-  - 'Canary Tests'
   - name: 'Deploy'
     if: branch = master AND type = push
 
 jobs:
-  fail_fast: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
-
   include:
-    # runs linting and tests with current locked deps
-
-    - stage: 'Tests'
-      name: 'Tests'
-      install:
-        - yarn install --non-interactive
-      script:
-        - yarn lint:ts
-        - yarn lint:hbs
-        - ember test
-
-    - name: 'Floating Dependencies'
-      script:
-        - ember test
-
-    # we recommend new addons test the current and previous LTS
-    # as well as latest stable release (bonus points to beta/canary)
-    - stage: 'Additional Tests'
-      node_js: 10
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
-
-    - stage: 'Canary Tests'
-      script:
-        - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
-      env: EMBER_TRY_SCENARIO=ember-canary
-
     - stage: 'Deploy'
       name: 'Publish to npm'
+      before_install:
+        - curl -o- -L https://yarnpkg.com/install.sh | bash
+        - export PATH=$HOME/.yarn/bin:$PATH
       install:
         - yarn install --non-interactive
       script: yarn semantic-release
-
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH
-
-install:
-  - yarn install --no-lockfile --non-interactive
-  - npm install -g codecov
-
-before_script:
-  - 'sudo chown root /opt/google/chrome/chrome-sandbox'
-  - 'sudo chmod 4755 /opt/google/chrome/chrome-sandbox'
-
-script:
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
-
-after_script:
-  - codecov


### PR DESCRIPTION
We have GitHub Actions for the CI tests now. We still need TravisCI for releases though until we can migrate that to GitHub Actions too.