### PR TITLE
fix: replace ember assign with Object.assign

### DIFF
--- a/addon/utils/collection-action.ts
+++ b/addon/utils/collection-action.ts
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import Model from 'ember-data/model';
 import { Value as JSONValue } from 'json-typescript';
 import { _getModelClass, _getModelName, _getStoreFromRecord, buildOperationUrl } from './build-url';
@@ -25,7 +24,7 @@ export default function collectionOp<IN = any, OUT = any>(options: CollectionOpe
     const fullUrl = buildOperationUrl(model, options.path, urlType, false);
     const data = (options.before && options.before.call(model, payload)) || payload;
     return adapter
-      .ajax(fullUrl, requestType, assign(options.ajaxOptions || {}, { data }))
+      .ajax(fullUrl, requestType, Object.assign(options.ajaxOptions || {}, { data }))
       .then((response: JSONValue) => {
         if (options.after && !model.isDestroyed) {
           return options.after.call(model, response);

--- a/addon/utils/member-action.ts
+++ b/addon/utils/member-action.ts
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import Model from 'ember-data/model';
 import { Value as JSONValue } from 'json-typescript';
 import { _getModelClass, _getModelName, _getStoreFromRecord, buildOperationUrl } from './build-url';
@@ -23,12 +22,14 @@ export default function instanceOp<IN = any, OUT = any>(options: InstanceOperati
     const adapter = store.adapterFor(modelName);
     const fullUrl = buildOperationUrl(this, path, urlType);
     const data = (before && before.call(this, payload)) || payload;
-    return adapter.ajax(fullUrl, requestType, assign(ajaxOptions || {}, { data })).then((response: JSONValue) => {
-      if (after && !this.isDestroyed) {
-        return after.call(this, response);
-      }
+    return adapter
+      .ajax(fullUrl, requestType, Object.assign(ajaxOptions || {}, { data }))
+      .then((response: JSONValue) => {
+        if (after && !this.isDestroyed) {
+          return after.call(this, response);
+        }
 
-      return response;
-    });
+        return response;
+      });
   };
 }

--- a/tests/dummy/app/models/fruit.js
+++ b/tests/dummy/app/models/fruit.js
@@ -1,5 +1,4 @@
 // BEGIN-SNIPPET fruit-model
-import { assign } from '@ember/polyfills';
 import { collectionAction, memberAction, serializeAndPush } from 'ember-api-actions';
 import DS from 'ember-data';
 
@@ -7,7 +6,7 @@ const { attr, Model } = DS;
 
 function mergeAttributes(attributes) {
   const payload = this.serialize();
-  payload.data.attributes = assign(payload.data.attributes || {}, attributes);
+  payload.data.attributes = Object.assign(payload.data.attributes || {}, attributes);
   return payload;
 }
 const Fruit = Model.extend({


### PR DESCRIPTION
Ember assign has been deprecated in [this RFC](https://deprecations.emberjs.com/v4.x/) and @ember/polyfills is no longer available in Ember 5.x.